### PR TITLE
[Feature] Add Solid Mode for writing scripts in GNU Emacs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ parser.h
 parser.c
 lexer.h
 lexer.c
+*.elc

--- a/README.md
+++ b/README.md
@@ -166,6 +166,10 @@ To put it all together, here's a complete example of embedding solid into a C pr
 
 But wait, what if you want to use C from inside solid, rather than solid from inside C? Well, you do (almost) the exact same thing. The `import` function is capable of loading shared libraries with the extension `.so`. When loaded, solid will call an arbitrary, user-defined function named `solid_init` with the signature `void solid_init(solid_vm *vm)` inside the library, passing it the current VM. From there, you can do everything that we did above, defining functions, modifying namespaces, etc. Don't want to go through the trouble to manually build a shared library? Solid has you covered. Just throw your C file `whatever.c` containing `solid_init` in the `lib` folder of the solid source tree, and run `make lib TARGET=whatever`, and it will create a shared library called `whatever.so` in the solid source root, which can now be freely imported.
 
+Extras
+------
+Programmers using [GNU Emacs](https://www.gnu.org/software/emacs/) can load [`solid-mode`](etc/solid-mode.el), providing basic syntax highlighting and formatting for Solid scripts.
+
 Contributing
 -------------
 Documentation is currently nonexistent outside of this file, but the code is pretty standard object-oriented C99 (generally one main struct per file, "methods" are functions that take a struct pointer as the first argument, everything is allocated with `malloc`). Start in ast.c and vm.c.

--- a/etc/solid-mode.el
+++ b/etc/solid-mode.el
@@ -1,0 +1,75 @@
+;;; solid-mode.el --- Major mode for writing Solid source code
+;;
+;; Copyright 2015 Eric James Michael Ritz
+;;
+;; Author: Eric James Michael Ritz <ejmr@plutono.com>
+;; URL: https://github.com/ejmr/Solid/blob/master/etc/solid-mode.el
+;; Version: 1.0.0
+;; Package-Requires: ((emacs "24"))
+;; Keywords: languages, programming
+;;
+;;
+;;
+;;; License:
+;;
+;; This file is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published
+;; by the Free Software Foundation; either version 3 of the License,
+;; or (at your option) any later version.
+;;
+;; This file is distributed in the hope that it will be useful, but
+;; WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+;; General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with this file; if not, write to the Free Software
+;; Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+;; 02110-1301, USA.
+;;
+;;
+;;
+;;; Commentary:
+;;
+;; This mode adds basic support to Emacs for writing software using
+;; the Solid programming language, available at:
+;;
+;;     https://github.com/chameco/Solid
+;;
+;; This package associates Solid Mode with files that have the "*.sol"
+;; filename extension.
+;;
+;;
+;;
+;;; Code:
+
+(defconst solid-mode-version-number "1.0.0"
+  "Solid Mode version number.
+
+This number adheres to Semantic Versioning (`http://semver.org/').")
+
+;;;###autoload
+(define-generic-mode 'solid-mode
+  ;; Comment Syntax
+  '("#")
+  ;; Keywords
+  '("if" "while" "fn" "do" "end" "return" "this" "ns")
+  ;; Operators and Other Syntax
+  '(("=" . font-lock-operator)
+    ("!!" . font-lock-operator)
+    ("~" . font-lock-builtin)
+    ("[" . font-lock-builtin)
+    ("]" . font-lock-builtin)
+    (";" . font-lock-builtin))
+  ;; Files
+  '("\\.sol$")
+  ;; Other Functions
+  nil
+  ;; Docstring
+  "Major mode for the Solid programming language.
+
+`https://github.com/chameco/Solid'")
+
+(provide 'solid-mode)
+
+;;; solid-mode.el ends here


### PR DESCRIPTION
This patch provides a mode for writing Solid code.  It offers basic
syntax highlighting for comments, keywords, and cetarin operators.

Signed-off-by: Eric James Michael Ritz ejmr@plutono.com
